### PR TITLE
Act 347 fix smb access

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 
 # OpenId Connect Generic Changelog
 
+**3.6.2**
+
+* Limited access to only partners, sales people, and admin.
+
 **3.6.1**
 
 * Updated the username so it doesn't remove all special characters.

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -407,6 +407,12 @@ class OpenID_Connect_Generic_Client {
 
 		// allow for other plugins to alter the login success
 		$login_user = apply_filters( 'openid-connect-generic-user-login-test', true, $user_claim );
+
+        // make sure they should have access
+		$roles = $user_claim['roles'];
+		if (!in_array('developer', $roles) and !in_array('partner', $roles) and !in_array('sales_person', $roles)) {
+		    return new WP_Error( 'unauthorized', __( 'Unauthorized access' ), $login_user );
+		}
 		
 		if ( ! $login_user ) {
 			return new WP_Error( 'unauthorized', __( 'Unauthorized access' ), $login_user );

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -3,7 +3,7 @@
 Plugin Name: Vendasta Fork of OpenID Connect Generic
 Plugin URI: https://github.com/vendasta/openid-connect-generic
 Description:  Connect to an OpenID Connect generic client using Authorization Code Flow
-Version: 3.6.1
+Version: 3.6.2
 Author: daggerhart
 Author URI: http://www.daggerhart.com
 License: GPLv2 Copyright (c) 2015 daggerhart
@@ -45,7 +45,7 @@ Notes
 
 class OpenID_Connect_Generic {
 	// plugin version
-	const VERSION = '3.6.1';
+	const VERSION = '3.6.2';
 
 	// plugin settings
 	private $settings;


### PR DESCRIPTION
Add access check to Academy

The academy wasn't checking the user type, just that use exists. Added a check, so only partners and sales people have access to the academy.


@vendasta/activision 
@vendasta/teamy-mcteamface 