### PR TITLE
Act 451 session deep link

### DIFF
--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -177,7 +177,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			wp_login_url() . 
 			'?login-error=' . $error->get_error_code() .
 		    '&message=' . urlencode( $error->get_error_message()) .
-		    '&redirect_to=' . urlencode('https://academy.conquerlocal.com/community/')
+		    '&redirect_to=' . urlencode('https://learndashtest.websitepro.hosting/contact/')
 		);
 		exit;
 	}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -137,7 +137,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			wp_logout();
 
 			if ( $this->settings->redirect_on_logout ) {
-			    $current_url = get_permalink(get_the_ID());
+			    $current_url = get_permalink(get_queried_object_id());
                 $this->logger->log("The current URL: {$current_url}");
 				$this->error_redirect( new WP_Error( 'access-token-expired', __( 'Session expired. Please login again.' ) ) );
 			}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -137,7 +137,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			wp_logout();
 
 			if ( $this->settings->redirect_on_logout ) {
-			    $current_url = get_permalink(get_queried_object_id());
+			    $current_url = home_url(add_query_arg(array(), $wp->request));
                 $this->logger->log("The current URL: {$current_url}");
 				$this->error_redirect( new WP_Error( 'access-token-expired', __( 'Session expired. Please login again.' ) ) );
 			}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -388,7 +388,6 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$this->logger->log( "Successful login for: {$user->user_login} ({$user->ID})", 'login-success' );
 
 		// redirect back to the origin page if enabled
-		sleep(3);
 		$redirect_url = isset( $_COOKIE[ $this->cookie_redirect_key ] ) ? esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) : false;
 		$this->logger->log("Going to redirect to this URL: {$redirect_url}");
 		$this->logger->log("Going to redirect to this cookie: {$_COOKIE[ $this->cookie_redirect_key ]}");
@@ -396,7 +395,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		if( $this->settings->redirect_user_back && !empty( $redirect_url ) ) {
 			do_action( 'openid-connect-generic-redirect-user-back', $redirect_url, $user );
 			setcookie( $this->cookie_redirect_key, $redirect_url, 1, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
-			$this->logger->log("The setting is set.");
+			//$this->logger->log("The setting is set.");
 			wp_redirect( $redirect_url );
 		}
 		// otherwise, go home!
@@ -475,7 +474,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$session = $manager->get($token);
 		$now = current_time( 'timestamp' , true );
 		$session[$this->cookie_token_refresh_key] = array(
-			'next_access_token_refresh_time' => 10 + $now,
+			'next_access_token_refresh_time' => $token_response['expires_in'] + $now,
 			'refresh_token' => isset( $token_response[ 'refresh_token' ] ) ? $token_response[ 'refresh_token' ] : false,
 			'refresh_expires' => false,
 		);

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -175,8 +175,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		wp_redirect(  
 			wp_login_url() . 
 			'?login-error=' . $error->get_error_code() .
-		    '&message=' . urlencode( $error->get_error_message()) .
-		    '&redirect_to=' . urlencode($current_url)
+		    '&message=' . urlencode( $error->get_error_message())
+		    //'&redirect_to=' . urlencode($current_url)
 		);
 		exit;
 	}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -389,7 +389,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$this->logger->log( "Successful login for: {$user->user_login} ({$user->ID})", 'login-success' );
 
 		// redirect back to the origin page if enabled
-		sleep(10);
+		sleep(3);
 		$redirect_url = isset( $_COOKIE[ $this->cookie_redirect_key ] ) ? esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) : false;
 		$this->logger->log("Going to redirect to this URL: {$redirect_url}");
 

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -389,6 +389,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$this->logger->log( "Successful login for: {$user->user_login} ({$user->ID})", 'login-success' );
 
 		// redirect back to the origin page if enabled
+		sleep(10);
 		$redirect_url = isset( $_COOKIE[ $this->cookie_redirect_key ] ) ? esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) : false;
 		$this->logger->log("Going to redirect to this URL: {$redirect_url}");
 

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -471,7 +471,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$session = $manager->get($token);
 		$now = current_time( 'timestamp' , true );
 		$session[$this->cookie_token_refresh_key] = array(
-			'next_access_token_refresh_time' => $token_response['expires_in'] + $now,
+			'next_access_token_refresh_time' => 10 + $now,
 			'refresh_token' => isset( $token_response[ 'refresh_token' ] ) ? $token_response[ 'refresh_token' ] : false,
 			'refresh_expires' => false,
 		);

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -469,7 +469,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$session = $manager->get($token);
 		$now = current_time( 'timestamp' , true );
 		$session[$this->cookie_token_refresh_key] = array(
-			'next_access_token_refresh_time' => 10 + $now, //$token_response['expires_in'] + $now,
+			'next_access_token_refresh_time' => $token_response['expires_in'] + $now,
 			'refresh_token' => isset( $token_response[ 'refresh_token' ] ) ? $token_response[ 'refresh_token' ] : false,
 			'refresh_expires' => false,
 		);

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -392,6 +392,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		sleep(3);
 		$redirect_url = isset( $_COOKIE[ $this->cookie_redirect_key ] ) ? esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) : false;
 		$this->logger->log("Going to redirect to this URL: {$redirect_url}");
+		$this->logger->log("Going to redirect to this cookie: {$_COOKIE[ $this->cookie_redirect_key ]}");
 
 		if( $this->settings->redirect_user_back && !empty( $redirect_url ) ) {
 			do_action( 'openid-connect-generic-redirect-user-back', $redirect_url, $user );

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -388,7 +388,6 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		// redirect back to the origin page if enabled
 		$redirect_url = isset( $_COOKIE[ $this->cookie_redirect_key ] ) ? esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) : false;
-		$this->logger->log("Going to redirect to this URL: {$redirect_url}");
 
 		if( $this->settings->redirect_user_back && !empty( $redirect_url ) ) {
 			do_action( 'openid-connect-generic-redirect-user-back', $redirect_url, $user );
@@ -397,7 +396,6 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		}
 		// otherwise, go home!
 		else {
-		    $this->logger->log("Redirecting home");
 			wp_redirect( home_url() );
 		}
 		

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -169,14 +169,16 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 */
 	function error_redirect( $error ) {
 		$current_url = home_url(add_query_arg(array(), $wp->request));
+		$current_url_2 = "//" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
         $this->logger->log("The current URL: {$current_url}");
+        $this->logger->log("The current URL 2: {$current_url_2}");
 		
 		// redirect user back to login page
 		wp_redirect(  
 			wp_login_url() . 
 			'?login-error=' . $error->get_error_code() .
-		    '&message=' . urlencode( $error->get_error_message())
-		    //'&redirect_to=' . urlencode($current_url)
+		    '&message=' . urlencode( $error->get_error_message()) .
+		    '&redirect_to=' . urlencode($current_url)
 		);
 		exit;
 	}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -126,14 +126,14 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		$next_access_token_refresh_time = $refresh_token_info[ 'next_access_token_refresh_time' ];
 
-		//if ( $current_time < $next_access_token_refresh_time ) {
-		//	return;
-		//}
+		if ( $current_time < $next_access_token_refresh_time ) {
+			return;
+		}
 
 		$refresh_token = $refresh_token_info[ 'refresh_token' ];
 		$refresh_expires = $refresh_token_info[ 'refresh_expires' ];
 
-		//if ( ! $refresh_token || ( $refresh_expires && $current_time > $refresh_expires ) ) {
+		if ( ! $refresh_token || ( $refresh_expires && $current_time > $refresh_expires ) ) {
 			wp_logout();
 
 			if ( $this->settings->redirect_on_logout ) {
@@ -143,7 +143,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			}
 
 			return;
-		//}
+		}
 
 		$token_result = $this->client->request_new_tokens( $refresh_token );
 		
@@ -176,8 +176,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		wp_redirect(  
 			wp_login_url() . 
 			'?login-error=' . $error->get_error_code() .
-		    '&message=' . urlencode( $error->get_error_message() .
-		    '&redirect_to=' . 'https://academy.conquerlocal.com/community/')
+		    '&message=' . urlencode( $error->get_error_message()) .
+		    '&redirect_to=' . urlencode('https://academy.conquerlocal.com/community/')
 		);
 		exit;
 	}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -168,10 +168,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 * @param $error WP_Error
 	 */
 	function error_redirect( $error ) {
-		$current_url = home_url(add_query_arg(array(), $wp->request));
-		$current_url_2 = "//" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-        $this->logger->log("The current URL: {$current_url}");
-        $this->logger->log("The current URL 2: {$current_url_2}");
+		$current_url = "https://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        $this->logger->log("The current URL 2: {$current_url}");
 		
 		// redirect user back to login page
 		wp_redirect(  

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -137,6 +137,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			wp_logout();
 
 			if ( $this->settings->redirect_on_logout ) {
+			    $current_url = get_permalink(get_the_ID());
+                $this->logger->log("The current URL: {$current_url}");
 				$this->error_redirect( new WP_Error( 'access-token-expired', __( 'Session expired. Please login again.' ) ) );
 			}
 
@@ -174,7 +176,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		wp_redirect(  
 			wp_login_url() . 
 			'?login-error=' . $error->get_error_code() .
-		    '&message=' . urlencode( $error->get_error_message() )
+		    '&message=' . urlencode( $error->get_error_message() .
+		    '&redirect_to=' . 'https://academy.conquerlocal.com/community/')
 		);
 		exit;
 	}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -176,8 +176,8 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		wp_redirect(  
 			wp_login_url() . 
 			'?login-error=' . $error->get_error_code() .
-		    '&message=' . urlencode( $error->get_error_message()) .
-		    '&redirect_to=' . urlencode('https://learndashtest.websitepro.hosting/contact/')
+		    '&message=' . urlencode( $error->get_error_message())
+		   // '&redirect_to=' . urlencode('https://learndashtest.websitepro.hosting/contact/')
 		);
 		exit;
 	}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -169,8 +169,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 */
 	function error_redirect( $error ) {
 		$current_url = "https://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-        $this->logger->log("The current URL 2: {$current_url}");
-		
+
 		// redirect user back to login page
 		wp_redirect(  
 			wp_login_url() . 
@@ -390,12 +389,10 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		// redirect back to the origin page if enabled
 		$redirect_url = isset( $_COOKIE[ $this->cookie_redirect_key ] ) ? esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) : false;
 		$this->logger->log("Going to redirect to this URL: {$redirect_url}");
-		$this->logger->log("Going to redirect to this cookie: {$_COOKIE[ $this->cookie_redirect_key ]}");
 
 		if( $this->settings->redirect_user_back && !empty( $redirect_url ) ) {
 			do_action( 'openid-connect-generic-redirect-user-back', $redirect_url, $user );
 			setcookie( $this->cookie_redirect_key, $redirect_url, 1, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
-			//$this->logger->log("The setting is set.");
 			wp_redirect( $redirect_url );
 		}
 		// otherwise, go home!
@@ -474,7 +471,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 		$session = $manager->get($token);
 		$now = current_time( 'timestamp' , true );
 		$session[$this->cookie_token_refresh_key] = array(
-			'next_access_token_refresh_time' => $token_response['expires_in'] + $now,
+			'next_access_token_refresh_time' => 10 + $now, //$token_response['expires_in'] + $now,
 			'refresh_token' => isset( $token_response[ 'refresh_token' ] ) ? $token_response[ 'refresh_token' ] : false,
 			'refresh_expires' => false,
 		);

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -126,14 +126,14 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		$next_access_token_refresh_time = $refresh_token_info[ 'next_access_token_refresh_time' ];
 
-		if ( $current_time < $next_access_token_refresh_time ) {
-			return;
-		}
+		//if ( $current_time < $next_access_token_refresh_time ) {
+		//	return;
+		//}
 
 		$refresh_token = $refresh_token_info[ 'refresh_token' ];
 		$refresh_expires = $refresh_token_info[ 'refresh_expires' ];
 
-		if ( ! $refresh_token || ( $refresh_expires && $current_time > $refresh_expires ) ) {
+		//if ( ! $refresh_token || ( $refresh_expires && $current_time > $refresh_expires ) ) {
 			wp_logout();
 
 			if ( $this->settings->redirect_on_logout ) {
@@ -143,7 +143,7 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			}
 
 			return;
-		}
+		//}
 
 		$token_result = $this->client->request_new_tokens( $refresh_token );
 		

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -137,8 +137,6 @@ class OpenID_Connect_Generic_Client_Wrapper {
 			wp_logout();
 
 			if ( $this->settings->redirect_on_logout ) {
-			    $current_url = home_url(add_query_arg(array(), $wp->request));
-                $this->logger->log("The current URL: {$current_url}");
 				$this->error_redirect( new WP_Error( 'access-token-expired', __( 'Session expired. Please login again.' ) ) );
 			}
 
@@ -170,14 +168,15 @@ class OpenID_Connect_Generic_Client_Wrapper {
 	 * @param $error WP_Error
 	 */
 	function error_redirect( $error ) {
-		$this->logger->log( $error );
+		$current_url = home_url(add_query_arg(array(), $wp->request));
+        $this->logger->log("The current URL: {$current_url}");
 		
 		// redirect user back to login page
 		wp_redirect(  
 			wp_login_url() . 
 			'?login-error=' . $error->get_error_code() .
-		    '&message=' . urlencode( $error->get_error_message())
-		   // '&redirect_to=' . urlencode('https://learndashtest.websitepro.hosting/contact/')
+		    '&message=' . urlencode( $error->get_error_message()) .
+		    '&redirect_to=' . urlencode($current_url)
 		);
 		exit;
 	}

--- a/includes/openid-connect-generic-client-wrapper.php
+++ b/includes/openid-connect-generic-client-wrapper.php
@@ -390,14 +390,17 @@ class OpenID_Connect_Generic_Client_Wrapper {
 
 		// redirect back to the origin page if enabled
 		$redirect_url = isset( $_COOKIE[ $this->cookie_redirect_key ] ) ? esc_url( $_COOKIE[ $this->cookie_redirect_key ] ) : false;
+		$this->logger->log("Going to redirect to this URL: {$redirect_url}");
 
 		if( $this->settings->redirect_user_back && !empty( $redirect_url ) ) {
 			do_action( 'openid-connect-generic-redirect-user-back', $redirect_url, $user );
 			setcookie( $this->cookie_redirect_key, $redirect_url, 1, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+			$this->logger->log("The setting is set.");
 			wp_redirect( $redirect_url );
 		}
 		// otherwise, go home!
 		else {
+		    $this->logger->log("Redirecting home");
 			wp_redirect( home_url() );
 		}
 		

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -65,7 +65,7 @@ class OpenID_Connect_Generic_Login_Form {
 		if ( $GLOBALS['pagenow'] == 'wp-login.php' && isset( $_GET[ 'action' ] ) && $_GET[ 'action' ] === 'logout' ) {
 			return;
 		}
-        $this->logger->log("Handle Redirect Cookie");
+        //$this->logger->log("Handle Redirect Cookie");
 		// record the URL of this page if set to redirect back to origin page
 		if ( $this->settings->redirect_user_back )
 		{
@@ -77,15 +77,15 @@ class OpenID_Connect_Generic_Login_Form {
 			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
 				// if using the login form, default redirect to the admin dashboard
 				$redirect_url = admin_url();
-                $this->logger->log("redirect page now");
+                //$this->logger->log("redirect page now");
 				if ( isset( $_REQUEST['redirect_to'] ) ) {
 					$redirect_url = esc_url( $_REQUEST[ 'redirect_to' ] );
-					$this->logger->log("Redirect URL: {$redirect_url}");
+					//$this->logger->log("Redirect URL: {$redirect_url}");
 				}
 			}
 
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
-            $this->logger->log("outside URL: {$redirect_url}");
+            //$this->logger->log("outside URL: {$redirect_url}");
 			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 		}
 	}

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -24,8 +24,6 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	static public function register( $settings, $client_wrapper, $logger ){
 
-	    $this->handle_redirect_cookie();
-
 		$login_form = new self( $settings, $client_wrapper, $logger );
 
 		// alter the login form as dictated by settings
@@ -33,6 +31,8 @@ class OpenID_Connect_Generic_Login_Form {
 
 		// add a shortcode for the login button
 		add_shortcode( 'openid_connect_generic_login_button', array( $login_form, 'make_login_button' ) );
+
+		$login_form->handle_redirect_cookie();
 
 		$login_form->handle_redirect_login_type_auto();
 

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -24,7 +24,7 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	static public function register( $settings, $client_wrapper, $logger ){
 
-	    add_action('init', 'handle_redirect_cookie');
+	    //add_action('init', 'handle_redirect_cookie');
 
 		$login_form = new self( $settings, $client_wrapper, $logger );
 
@@ -103,6 +103,7 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_login_page( $message ) {
         $this->logger->log("Handle login page");
+        $this->handle_redirect_cookie();
 		if ( isset( $_GET['login-error'] ) ) {
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -83,13 +83,14 @@ class OpenID_Connect_Generic_Login_Form {
 					//$this->logger->log("Redirect URL: {$redirect_url}");
 				}
 			}
-            // ob_start function  ??? Use this  //todo figure out how to set cookies in function.
+            ob_start()
+
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
             //$this->logger->log("outside URL: {$redirect_url}");
 			$success = setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 			$this->logger->log("cookie is set {$success}");
 
-			// ob_end_clean function ??? Use this.
+			ob_end_clean()
 		}
 	}
 
@@ -139,17 +140,18 @@ class OpenID_Connect_Generic_Login_Form {
 		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login' ) );
 		$href = $this->client_wrapper->get_authentication_url();
 
-		ob_start();
+
 
 		// maybe set redirect cookie on formular page
 		$this->handle_redirect_cookie();
 
+        ob_start();
 		?>
 		<div class="openid-connect-login-button" style="margin: 1em 0; text-align: center; color: #3fb23f;">
 			<a class="button button-large" href="<?php print esc_url( $href ); ?>"><?php print $text; ?></a>
 		</div>
 		<?php
-		return ob_get_flush();
+		return ob_get_clean();
 	}
 
 	/*

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -23,9 +23,10 @@ class OpenID_Connect_Generic_Login_Form {
 	 * @return \OpenID_Connect_Generic_Login_Form
 	 */
 	static public function register( $settings, $client_wrapper, $logger ){
-		$login_form = new self( $settings, $client_wrapper, $logger );
 
-		add_action('init', 'handle_redirect_cookie');
+	    add_action('init', 'handle_redirect_cookie');
+
+		$login_form = new self( $settings, $client_wrapper, $logger );
 
 		// alter the login form as dictated by settings
 		add_filter( 'login_message', array( $login_form, 'handle_login_page' ), 99 );

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -88,9 +88,10 @@ class OpenID_Connect_Generic_Login_Form {
 			}
 
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
-            //$this->logger->log("outside URL: {$redirect_url}");
+            $this->logger->log("outside URL: {$redirect_url}");
 			$success = setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 			$this->logger->log("cookie is set {$success}");
+			$this->logger->log($_COOKIE[ $this->cookie_redirect_key ]);
 
 		}
 	}
@@ -102,6 +103,7 @@ class OpenID_Connect_Generic_Login_Form {
 	 * @return string
 	 */
 	function handle_login_page( $message ) {
+	    ob_start();
         $this->logger->log("Handle login page");
         $this->handle_redirect_cookie();
 		if ( isset( $_GET['login-error'] ) ) {
@@ -110,6 +112,7 @@ class OpenID_Connect_Generic_Login_Form {
 
 		// login button is appended to existing messages in case of error
 		$message .= $this->make_login_button();
+		ob_end_clean();
 		return $message;
 	}
 
@@ -122,7 +125,7 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function make_error_output( $error_code, $error_message ) {
 
-		ob_start();
+		//ob_start();
 		?>
 		<div id="login_error">
 			<strong><?php _e( 'ERROR'); ?>: </strong>
@@ -147,7 +150,7 @@ class OpenID_Connect_Generic_Login_Form {
 		// maybe set redirect cookie on formular page
 		//$this->handle_redirect_cookie();
 
-        ob_start();
+      //  ob_start();
 		?>
 		<div class="openid-connect-login-button" style="margin: 1em 0; text-align: center; color: #3fb23f;">
 			<a class="button button-large" href="<?php print esc_url( $href ); ?>"><?php print $text; ?></a>

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -102,7 +102,7 @@ class OpenID_Connect_Generic_Login_Form {
         $this->logger->log("Handle login page");
 
 		if ( isset( $_GET['login-error'] ) ) {
-		    add_action( 'init', array( $this, 'handle_redirect_cookie' ), 99 );
+		   // add_action( 'init', array( $this, 'handle_redirect_cookie' ), 99 );
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}
 

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -67,7 +67,6 @@ class OpenID_Connect_Generic_Login_Form {
 		if ( $GLOBALS['pagenow'] == 'wp-login.php' && isset( $_GET[ 'action' ] ) && $_GET[ 'action' ] === 'logout' ) {
 			return;
 		}
-        $this->logger->log("Handle Redirect Cookie");
 		// record the URL of this page if set to redirect back to origin page
 		if ( $this->settings->redirect_user_back )
 		{
@@ -85,8 +84,7 @@ class OpenID_Connect_Generic_Login_Form {
 			}
 
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
-            $this->logger->log("outside URL: {$redirect_url}");
-			$success = setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 
 		}
 	}
@@ -98,7 +96,6 @@ class OpenID_Connect_Generic_Login_Form {
 	 * @return string
 	 */
 	function handle_login_page( $message ) {
-        $this->logger->log("Handle login page");
 
 		if ( isset( $_GET['login-error'] ) ) {
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
@@ -134,7 +131,6 @@ class OpenID_Connect_Generic_Login_Form {
 	 * @return string
 	 */
 	function make_login_button() {
-	    $this->logger->log("Make login button");
 		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login' ) );
 		$href = $this->client_wrapper->get_authentication_url();
 

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -24,6 +24,8 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	static public function register( $settings, $client_wrapper, $logger ){
 
+	    $this->handle_redirect_cookie();
+
 		$login_form = new self( $settings, $client_wrapper, $logger );
 
 		// alter the login form as dictated by settings

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -100,8 +100,9 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_login_page( $message ) {
         $this->logger->log("Handle login page");
-        add_action( 'init', array( $this, 'handle_redirect_cookie' ), 99 );
+
 		if ( isset( $_GET['login-error'] ) ) {
+		    add_action( 'init', array( $this, 'handle_redirect_cookie' ), 99 );
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}
 

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -102,7 +102,7 @@ class OpenID_Connect_Generic_Login_Form {
         $this->logger->log("Handle login page");
 
 		if ( isset( $_GET['login-error'] ) ) {
-		   // add_action( 'init', array( $this, 'handle_redirect_cookie' ), 99 );
+		   // add_action( 'init', array( $this, 'handle_redirect_cookie' ) );
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}
 

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -50,7 +50,7 @@ class OpenID_Connect_Generic_Login_Form {
 			&& ! isset( $_POST['wp-submit'] ) )
 		{
 			if (  ! isset( $_GET['login-error'] ) ) {
-			   // $this->handle_redirect_cookie();
+			    $this->handle_redirect_cookie();
 				wp_redirect( $this->client_wrapper->get_authentication_url() );
 				exit;
 			}
@@ -103,7 +103,7 @@ class OpenID_Connect_Generic_Login_Form {
 	 * @return string
 	 */
 	function handle_login_page( $message ) {
-	    ob_start();
+	   // ob_start();
         $this->logger->log("Handle login page");
         $this->handle_redirect_cookie();
 		if ( isset( $_GET['login-error'] ) ) {
@@ -112,7 +112,7 @@ class OpenID_Connect_Generic_Login_Form {
 
 		// login button is appended to existing messages in case of error
 		$message .= $this->make_login_button();
-		ob_end_clean();
+		//ob_end_clean();
 		return $message;
 	}
 
@@ -125,7 +125,7 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function make_error_output( $error_code, $error_message ) {
 
-		//ob_start();
+		ob_start();
 		?>
 		<div id="login_error">
 			<strong><?php _e( 'ERROR'); ?>: </strong>
@@ -150,7 +150,7 @@ class OpenID_Connect_Generic_Login_Form {
 		// maybe set redirect cookie on formular page
 		//$this->handle_redirect_cookie();
 
-      //  ob_start();
+        ob_start();
 		?>
 		<div class="openid-connect-login-button" style="margin: 1em 0; text-align: center; color: #3fb23f;">
 			<a class="button button-large" href="<?php print esc_url( $href ); ?>"><?php print $text; ?></a>

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -25,6 +25,8 @@ class OpenID_Connect_Generic_Login_Form {
 	static public function register( $settings, $client_wrapper, $logger ){
 		$login_form = new self( $settings, $client_wrapper, $logger );
 
+		add_action('init', 'handle_redirect_cookie');
+
 		// alter the login form as dictated by settings
 		add_filter( 'login_message', array( $login_form, 'handle_login_page' ), 99 );
 
@@ -47,7 +49,7 @@ class OpenID_Connect_Generic_Login_Form {
 			&& ! isset( $_POST['wp-submit'] ) )
 		{
 			if (  ! isset( $_GET['login-error'] ) ) {
-			    $this->handle_redirect_cookie();
+			   // $this->handle_redirect_cookie();
 				wp_redirect( $this->client_wrapper->get_authentication_url() );
 				exit;
 			}
@@ -65,7 +67,7 @@ class OpenID_Connect_Generic_Login_Form {
 		if ( $GLOBALS['pagenow'] == 'wp-login.php' && isset( $_GET[ 'action' ] ) && $_GET[ 'action' ] === 'logout' ) {
 			return;
 		}
-        //$this->logger->log("Handle Redirect Cookie");
+        $this->logger->log("Handle Redirect Cookie");
 		// record the URL of this page if set to redirect back to origin page
 		if ( $this->settings->redirect_user_back )
 		{
@@ -83,14 +85,12 @@ class OpenID_Connect_Generic_Login_Form {
 					//$this->logger->log("Redirect URL: {$redirect_url}");
 				}
 			}
-            ob_start()
 
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
             //$this->logger->log("outside URL: {$redirect_url}");
 			$success = setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 			$this->logger->log("cookie is set {$success}");
 
-			ob_end_clean()
 		}
 	}
 
@@ -143,7 +143,7 @@ class OpenID_Connect_Generic_Login_Form {
 
 
 		// maybe set redirect cookie on formular page
-		$this->handle_redirect_cookie();
+		//$this->handle_redirect_cookie();
 
         ob_start();
 		?>

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -97,7 +97,6 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_login_page( $message ) {
         $this->logger->log("Handle login page");
-        add_action( 'init', array( $this, 'handle_redirect_cookie' ) );
 
 		if ( isset( $_GET['login-error'] ) ) {
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
@@ -139,8 +138,8 @@ class OpenID_Connect_Generic_Login_Form {
 
         ob_start();
 		?>
-		<div class="openid-connect-login-button" style="margin: 1em 0; text-align: center; color: #3fb23f;">
-			<a class="button button-large" href="<?php print esc_url( $href ); ?>"><?php print $text; ?></a>
+		<div class="openid-connect-login-button" style="margin: 1em 0; text-align: center;">
+			<a class="button button-large" style="color: #3fb23f;" href="<?php print esc_url( $href ); ?>"><?php print $text; ?></a>
 		</div>
 		<?php
 		return ob_get_clean();

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -83,10 +83,13 @@ class OpenID_Connect_Generic_Login_Form {
 					//$this->logger->log("Redirect URL: {$redirect_url}");
 				}
 			}
-
+            // ob_start function  ??? Use this  //todo figure out how to set cookies in function.
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
             //$this->logger->log("outside URL: {$redirect_url}");
-			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+			$success = setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+			$this->logger->log("cookie is set {$success}");
+
+			// ob_end_clean function ??? Use this.
 		}
 	}
 
@@ -136,16 +139,17 @@ class OpenID_Connect_Generic_Login_Form {
 		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login' ) );
 		$href = $this->client_wrapper->get_authentication_url();
 
+		ob_start();
+
 		// maybe set redirect cookie on formular page
 		$this->handle_redirect_cookie();
 
-		ob_start();
 		?>
-		<div class="openid-connect-login-button" style="margin: 1em 0; text-align: center;">
+		<div class="openid-connect-login-button" style="margin: 1em 0; text-align: center; color: #3fb23f;">
 			<a class="button button-large" href="<?php print esc_url( $href ); ?>"><?php print $text; ?></a>
 		</div>
 		<?php
-		return ob_get_clean();
+		return ob_get_flush();
 	}
 
 	/*

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -129,7 +129,7 @@ class OpenID_Connect_Generic_Login_Form {
 	 * @return string
 	 */
 	function make_login_button() {
-		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login with OpenID Connect' ) );
+		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login' ) );
 		$href = $this->client_wrapper->get_authentication_url();
 
 		// maybe set redirect cookie on formular page

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -50,7 +50,9 @@ class OpenID_Connect_Generic_Login_Form {
 			&& ! isset( $_POST['wp-submit'] ) )
 		{
 			if (  ! isset( $_GET['login-error'] ) ) {
+			    ob_start();
 			    $this->handle_redirect_cookie();
+			    ob_end_flush();
 				wp_redirect( $this->client_wrapper->get_authentication_url() );
 				exit;
 			}

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -24,8 +24,6 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	static public function register( $settings, $client_wrapper, $logger ){
 
-	    //add_action('init', 'handle_redirect_cookie');
-
 		$login_form = new self( $settings, $client_wrapper, $logger );
 
 		// alter the login form as dictated by settings
@@ -50,9 +48,9 @@ class OpenID_Connect_Generic_Login_Form {
 			&& ! isset( $_POST['wp-submit'] ) )
 		{
 			if (  ! isset( $_GET['login-error'] ) ) {
-			    ob_start();
-			    $this->handle_redirect_cookie();
-			    ob_end_flush();
+// 			    ob_start();
+// 			    $this->handle_redirect_cookie();
+// 			    ob_end_flush();
 				wp_redirect( $this->client_wrapper->get_authentication_url() );
 				exit;
 			}
@@ -82,17 +80,14 @@ class OpenID_Connect_Generic_Login_Form {
 			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
 				// if using the login form, default redirect to the admin dashboard
 				$redirect_url = admin_url();
-                //$this->logger->log("redirect page now");
 				if ( isset( $_REQUEST['redirect_to'] ) ) {
 					$redirect_url = esc_url( $_REQUEST[ 'redirect_to' ] );
-					//$this->logger->log("Redirect URL: {$redirect_url}");
 				}
 			}
 
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
             $this->logger->log("outside URL: {$redirect_url}");
 			$success = setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
-			$this->logger->log("cookie is set {$success}");
 
 		}
 	}
@@ -104,19 +99,13 @@ class OpenID_Connect_Generic_Login_Form {
 	 * @return string
 	 */
 	function handle_login_page( $message ) {
-	   // ob_start();
         $this->logger->log("Handle login page");
-//         ob_start();
-//         $this->handle_redirect_cookie();
-//         ob_end_flush();
-       // add_action('init', 'handle_redirect_cookie');
 		if ( isset( $_GET['login-error'] ) ) {
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}
 
 		// login button is appended to existing messages in case of error
 		$message .= $this->make_login_button();
-		//ob_end_clean();
 		return $message;
 	}
 
@@ -148,11 +137,6 @@ class OpenID_Connect_Generic_Login_Form {
 	    $this->logger->log("Make login button");
 		$text = apply_filters( 'openid-connect-generic-login-button-text', __( 'Login' ) );
 		$href = $this->client_wrapper->get_authentication_url();
-
-
-
-		// maybe set redirect cookie on formular page
-		//$this->handle_redirect_cookie();
 
         ob_start();
 		?>

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -48,9 +48,6 @@ class OpenID_Connect_Generic_Login_Form {
 			&& ! isset( $_POST['wp-submit'] ) )
 		{
 			if (  ! isset( $_GET['login-error'] ) ) {
-// 			    ob_start();
-// 			    $this->handle_redirect_cookie();
-// 			    ob_end_flush();
 				wp_redirect( $this->client_wrapper->get_authentication_url() );
 				exit;
 			}
@@ -100,9 +97,9 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_login_page( $message ) {
         $this->logger->log("Handle login page");
+        add_action( 'init', array( $this, 'handle_redirect_cookie' ) );
 
 		if ( isset( $_GET['login-error'] ) ) {
-		   // add_action( 'init', array( $this, 'handle_redirect_cookie' ) );
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}
 

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -93,7 +93,6 @@ class OpenID_Connect_Generic_Login_Form {
             $this->logger->log("outside URL: {$redirect_url}");
 			$success = setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 			$this->logger->log("cookie is set {$success}");
-			$this->logger->log($_COOKIE[ $this->cookie_redirect_key ]);
 
 		}
 	}
@@ -107,9 +106,10 @@ class OpenID_Connect_Generic_Login_Form {
 	function handle_login_page( $message ) {
 	   // ob_start();
         $this->logger->log("Handle login page");
-        ob_start();
-        $this->handle_redirect_cookie();
-        ob_end_flush();
+//         ob_start();
+//         $this->handle_redirect_cookie();
+//         ob_end_flush();
+       // add_action('init', 'handle_redirect_cookie');
 		if ( isset( $_GET['login-error'] ) ) {
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -107,7 +107,9 @@ class OpenID_Connect_Generic_Login_Form {
 	function handle_login_page( $message ) {
 	   // ob_start();
         $this->logger->log("Handle login page");
+        ob_start();
         $this->handle_redirect_cookie();
+        ob_end_flush();
 		if ( isset( $_GET['login-error'] ) ) {
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -100,6 +100,7 @@ class OpenID_Connect_Generic_Login_Form {
 	 */
 	function handle_login_page( $message ) {
         $this->logger->log("Handle login page");
+        add_action( 'init', array( $this, 'handle_redirect_cookie' ), 99 );
 		if ( isset( $_GET['login-error'] ) ) {
 			$message .= $this->make_error_output( $_GET['login-error'], $_GET['message'] );
 		}

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -107,8 +107,6 @@ class OpenID_Connect_Generic {
 
 		$this->login_form = OpenID_Connect_Generic_Login_Form::register( $this->settings, $this->client_wrapper, $this->logger );
 
-		// $this->login_form->handle_redirect_cookie();
-
 		// add a shortcode to get the auth url
 		add_shortcode( 'openid_connect_generic_auth_url', array( $this->client_wrapper, 'get_authentication_url' ) );
 

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -107,6 +107,8 @@ class OpenID_Connect_Generic {
 
 		$this->login_form = OpenID_Connect_Generic_Login_Form::register( $this->settings, $this->client_wrapper, $this->logger );
 
+		$this->login_form->handle_redirect_cookie();
+
 		// add a shortcode to get the auth url
 		add_shortcode( 'openid_connect_generic_auth_url', array( $this->client_wrapper, 'get_authentication_url' ) );
 

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -3,7 +3,7 @@
 Plugin Name: Vendasta Fork of OpenID Connect Generic
 Plugin URI: https://github.com/vendasta/openid-connect-generic
 Description:  Connect to an OpenID Connect generic client using Authorization Code Flow
-Version: 3.6.1
+Version: 3.6.3
 Author: daggerhart
 Author URI: http://www.daggerhart.com
 License: GPLv2 Copyright (c) 2015 daggerhart
@@ -45,7 +45,7 @@ Notes
 
 class OpenID_Connect_Generic {
 	// plugin version
-	const VERSION = '3.6.1';
+	const VERSION = '3.6.3';
 
 	// plugin settings
 	private $settings;

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -107,7 +107,7 @@ class OpenID_Connect_Generic {
 
 		$this->login_form = OpenID_Connect_Generic_Login_Form::register( $this->settings, $this->client_wrapper, $this->logger );
 
-		$this->login_form->handle_redirect_cookie();
+		// $this->login_form->handle_redirect_cookie();
 
 		// add a shortcode to get the auth url
 		add_shortcode( 'openid_connect_generic_auth_url', array( $this->client_wrapper, 'get_authentication_url' ) );

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -107,7 +107,7 @@ class OpenID_Connect_Generic {
 
 		$this->login_form = OpenID_Connect_Generic_Login_Form::register( $this->settings, $this->client_wrapper, $this->logger );
 
-		//$this->login_form->handle_redirect_cookie();
+		$this->login_form->handle_redirect_cookie();
 
 		// add a shortcode to get the auth url
 		add_shortcode( 'openid_connect_generic_auth_url', array( $this->client_wrapper, 'get_authentication_url' ) );

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -107,7 +107,7 @@ class OpenID_Connect_Generic {
 
 		$this->login_form = OpenID_Connect_Generic_Login_Form::register( $this->settings, $this->client_wrapper, $this->logger );
 
-		$this->login_form->handle_redirect_cookie();
+		//$this->login_form->handle_redirect_cookie();
 
 		// add a shortcode to get the auth url
 		add_shortcode( 'openid_connect_generic_auth_url', array( $this->client_wrapper, 'get_authentication_url' ) );

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -105,7 +105,7 @@ class OpenID_Connect_Generic {
 			return;
 		}
 
-		$this->login_form = OpenID_Connect_Generic_Login_Form::register( $this->settings, $this->client_wrapper );
+		$this->login_form = OpenID_Connect_Generic_Login_Form::register( $this->settings, $this->client_wrapper, $this->logger );
 
 		// add a shortcode to get the auth url
 		add_shortcode( 'openid_connect_generic_auth_url', array( $this->client_wrapper, 'get_authentication_url' ) );


### PR DESCRIPTION
When the user encountered an error, once the error was dismissed, the user was taken to the home page. The most common error is the session expired error. When the user logs in, it will now continue to the page the user was trying to browse to before encountering the error.

Also changed the login button on the error screen, to just say "Login" with green text.