### PR TITLE
Fix no code error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 
 # OpenId Connect Generic Changelog
+**3.6.4**
+
+* Fixed 'No authentication code present in the request.' error from happening
+  after getting a missing state. 
+* Changed error message for 'Missing State" to be more user friendly.
+
 **3.6.3**
 
 * Fixed deep linking after encountering error screen.

--- a/includes/openid-connect-generic-client.php
+++ b/includes/openid-connect-generic-client.php
@@ -80,7 +80,7 @@ class OpenID_Connect_Generic_Client {
 
 		// check the client request state 
 		if ( ! isset( $request['state'] ) || ! $this->check_state( $request['state'] ) ){
-			return new WP_Error( 'missing-state', __( 'Missing state.' ), $request );
+			return new WP_Error( 'missing-state', __( 'Session Expired. Please log in below.' ), $request );
 		}
 
 		return $request;

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -76,7 +76,7 @@ class OpenID_Connect_Generic_Login_Form {
 			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
 				// if using the login form, default redirect to the admin dashboard
 				$redirect_url = admin_url();
-				if ( isset( $_REQUEST['redirect_to'] ) ) {
+				if ( isset( $_REQUEST['redirect_to'] ) && ( strpos($_REQUEST['redirect_to'], 'admin-ajax') === false )) {
 					$redirect_url = esc_url( $_REQUEST[ 'redirect_to' ] );
 				}
 			}

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -3,7 +3,7 @@
 Plugin Name: Vendasta Fork of OpenID Connect Generic
 Plugin URI: https://github.com/vendasta/openid-connect-generic
 Description:  Connect to an OpenID Connect generic client using Authorization Code Flow
-Version: 3.6.3
+Version: 3.6.4
 Author: daggerhart
 Author URI: http://www.daggerhart.com
 License: GPLv2 Copyright (c) 2015 daggerhart
@@ -45,7 +45,7 @@ Notes
 
 class OpenID_Connect_Generic {
 	// plugin version
-	const VERSION = '3.6.3';
+	const VERSION = '3.6.4';
 
 	// plugin settings
 	private $settings;


### PR DESCRIPTION
Fix No Code error

When the user would get a 'State Expired' error, they would press the login button, and it would take them to another error 'No authentication code present in the request.'  They would then be stuck on this page.  This was happening, because there were two requests being fired off when logging in. The second one would not have any params, and so when it was authenticated, it would display this error.

This was happening because when the 'redirect_to' param was fixed to properly redirect the user once an error was encountered, it was saving the ajax auth callback as the redirect URL.  This resulted in a second call (in this case), which was causing the error.

Fixed the redirect_to url, so it won't save this auth callback URL.