### PR TITLE
Remove redirect admin

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 
 # OpenId Connect Generic Changelog
+**3.6.5**
+
+* Removed redirect to admin dashboard as a default. Should now redirect to
+home page
+
 **3.6.4**
 
 * Fixed 'No authentication code present in the request.' error from happening

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -74,8 +74,6 @@ class OpenID_Connect_Generic_Login_Form {
 			$redirect_url = home_url( esc_url( add_query_arg( null, null ) ) );
 
 			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
-				// if using the login form, default redirect to the admin dashboard
-				$redirect_url = admin_url();
 				if ( isset( $_REQUEST['redirect_to'] ) && ( strpos($_REQUEST['redirect_to'], 'admin-ajax') === false )) {
 					$redirect_url = esc_url( $_REQUEST[ 'redirect_to' ] );
 				}

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -3,7 +3,7 @@
 Plugin Name: Vendasta Fork of OpenID Connect Generic
 Plugin URI: https://github.com/vendasta/openid-connect-generic
 Description:  Connect to an OpenID Connect generic client using Authorization Code Flow
-Version: 3.6.4
+Version: 3.6.5
 Author: daggerhart
 Author URI: http://www.daggerhart.com
 License: GPLv2 Copyright (c) 2015 daggerhart
@@ -45,7 +45,7 @@ Notes
 
 class OpenID_Connect_Generic {
 	// plugin version
-	const VERSION = '3.6.4';
+	const VERSION = '3.6.5';
 
 	// plugin settings
 	private $settings;


### PR DESCRIPTION
Redirecting the user properly

When there is no redirect_url set, it is redirecting the user to the admin dashboard after logging in.
It should just redirect the user to the main page.

Removed code that does the admin dashboard redirect.