### PR TITLE
Act 582 fix login bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 
 # OpenId Connect Generic Changelog
+**3.7.2**
+
+* Fix: Authentication URL was being called twice on initial page load causing error.
+
 **3.7.1**
 
 * Fix: Release Version Number.

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -75,12 +75,12 @@ class OpenID_Connect_Generic_Login_Form {
 			// default redirect to the homepage
 			$redirect_url = home_url( esc_url( add_query_arg( null, null ) ) );
 
-			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
+		    if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
 
-				// Vendasta -- don't save authentication URL to redirect cookie.
+			    // Vendasta -- don't save authentication URL to redirect cookie.
                 if ( isset( $_REQUEST['redirect_to'] ) && ( strpos($_REQUEST['redirect_to'], 'admin-ajax') === false )) {
-					$redirect_url = esc_url_raw( $_REQUEST[ 'redirect_to' ] );
-				}
+	                $redirect_url = esc_url_raw( $_REQUEST[ 'redirect_to' ] );
+                }
 			}
 
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -75,13 +75,13 @@ class OpenID_Connect_Generic_Login_Form {
 			// default redirect to the homepage
 			$redirect_url = home_url( esc_url( add_query_arg( null, null ) ) );
 
-		    if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
+            if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
 
-			    // Vendasta -- don't save authentication URL to redirect cookie.
+                // Vendasta -- don't save authentication URL to redirect cookie.
                 if ( isset( $_REQUEST['redirect_to'] ) && ( strpos($_REQUEST['redirect_to'], 'admin-ajax') === false )) {
-	                $redirect_url = esc_url_raw( $_REQUEST[ 'redirect_to' ] );
+                    $redirect_url = esc_url_raw( $_REQUEST[ 'redirect_to' ] );
                 }
-			}
+            }
 
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
 			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );

--- a/includes/openid-connect-generic-login-form.php
+++ b/includes/openid-connect-generic-login-form.php
@@ -77,13 +77,13 @@ class OpenID_Connect_Generic_Login_Form {
 
 			if ( $GLOBALS['pagenow'] == 'wp-login.php' ) {
 
-				if ( isset( $_REQUEST['redirect_to'] ) ) {
+				// Vendasta -- don't save authentication URL to redirect cookie.
+                if ( isset( $_REQUEST['redirect_to'] ) && ( strpos($_REQUEST['redirect_to'], 'admin-ajax') === false )) {
 					$redirect_url = esc_url_raw( $_REQUEST[ 'redirect_to' ] );
 				}
 			}
 
 			$redirect_url = apply_filters( 'openid-connect-generic-cookie-redirect-url', $redirect_url );
-
 			setcookie( $this->client_wrapper->cookie_redirect_key, $redirect_url, $redirect_expiry, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 		}
 	}

--- a/openid-connect-generic.php
+++ b/openid-connect-generic.php
@@ -17,7 +17,7 @@
  * Plugin Name:       Vendasta Fork of OpenID Connect Generic
  * Plugin URI:        https://github.com/daggerhart/openid-connect-generic
  * Description:       Connect to an OpenID Connect generic client using Authorization Code Flow.
- * Version:           3.7.1
+ * Version:           3.7.2
  * Author:            daggerhart
  * Author URI:        http://www.daggerhart.com
  * License:           GPL-2.0+
@@ -62,7 +62,7 @@ Notes
 
 class OpenID_Connect_Generic {
 	// plugin version
-	const VERSION = '3.7.1';
+	const VERSION = '3.7.2';
 
 	// plugin settings
 	private $settings;


### PR DESCRIPTION
Bug:
When logging in, sometimes would get this error:
"ERROR: Provided code is either already used, expired or invalid. cache miss"

Problem:
When logging in, an authentication URL is sent to authenticate the user. This was being saved to the redirect cookie, so it was being called twice. The first one would pass, and the second one would fail with the above error. 

Solution:
Don't save this URL to the redirect URL cookie, so it will only be called once.